### PR TITLE
update works with optional fields

### DIFF
--- a/app/crud/issues.py
+++ b/app/crud/issues.py
@@ -240,21 +240,19 @@ def update(id: int, issue: Issues):
         WHERE id = %s
         RETURNING id, vendor_id, updated_at
     '''
-    params = (
-        issue.vendor_id,
-        issue.type,
-        issue.description,
-        issue.summary,
-        issue.severity,
-        issue.status,
-        issue.active,
-        issue.image_url,
-        id
-    )
-
     try:
         with get_db_cursor() as cursor:
-            cursor.execute(query, params)
+            cursor.execute(query, (
+                issue.vendor_id,
+                issue.type,
+                issue.description,
+                issue.summary,
+                issue.severity,
+                issue.status,
+                issue.active,
+                issue.image_url,
+                id
+            ))
             updated_issue = cursor.fetchone()
             return dict(updated_issue)
     except Exception as e:


### PR DESCRIPTION
Previously, the update method assumed all fields (including optional ones like vendor_id, description, etc.) would always be present in the request body.

This caused errors when the frontend attempted to update issues that were missing these optional fields.

This PR updates the update logic to check for each optional field and insert NULL into the SQL query when a value is not provided.

Tested locally to confirm updates work as expected with and without optional fields.