### PR TITLE
creating a user also creates stripe user information

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from pydantic_settings import BaseSettings
+import stripe
 
 class Settings(BaseSettings):
     DB_HOST: str
@@ -33,6 +34,7 @@ def get_settings():
     return Settings()
 
 settings = get_settings()
+stripe.api_key = settings.STRIPE_SECRET_KEY
 
 if __name__ == "__main__":
     print(settings.DATABASE_URL)


### PR DESCRIPTION
Integrated Stripe customer creation into the user signup flow.
On `User `creation, a corresponding Stripe customer is saved in `user_stripe_information`.
Added cleanup logic:
If Stripe creation fails → the user row is rolled back.
If linking fails → both the user and Stripe customer are removed to prevent orphans.
Input and output of the API remain unchanged (Users payload in, user record out), so this update should not break any existing frontend functionality.

Please review thanks!
